### PR TITLE
开黑啦重命名为 `KOOK`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /data/token.txt
 
 # my files
-/src/test/kotlin/io/github/zly2006/khlkt/test/me/*
+/src/test/kotlin/io/github/zly2006/kookybot/test/me/*

--- a/.idea/artifacts/KookyBot_all.xml
+++ b/.idea/artifacts/KookyBot_all.xml
@@ -1,8 +1,8 @@
 <component name="ArtifactManager">
-  <artifact type="jar" name="KhlKt-all">
-    <output-path>$PROJECT_DIR$/out/artifacts/KhlKt_all</output-path>
-    <root id="archive" name="KhlKt.jar">
-      <element id="module-output" name="KhlKt.main" />
+  <artifact type="jar" name="KookyBot-all">
+    <output-path>$PROJECT_DIR$/out/artifacts/KookyBot_all</output-path>
+    <root id="archive" name="KookyBot.jar">
+      <element id="module-output" name="KookyBot.main" />
       <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.java-websocket/Java-WebSocket/1.5.3/9c26b6a6e732a1242db576a50dc3a12e446e2717/Java-WebSocket-1.5.3.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.core/jackson-databind/2.9.6/cfa4f316351a91bfd95cb0644c6a2c95f52db1fc/jackson-databind-2.9.6.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jetty.websocket/websocket-servlet/9.4.46.v20220331/235d1e5741f3aaace077003c0c20681305ee3303/websocket-servlet-9.4.46.v20220331.jar" path-in-jar="/" />

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **简体中文** | [English](README_en.md)
 
-JVM平台上的开黑啦Bot SDK
+JVM 平台上的 KOOK (原开黑啦) Bot SDK
 
 ## Quick Starting
 
-1. 在Releases下载下载最新版jar或clone本仓库编译jar
+1. 在 [Releases](https://github.com/zly2006/KookyBot/releases) 下载下载最新版jar或clone本仓库编译jar
 2. 新建一个java或kotlin项目，并把jar作为库导入
 3. 写下你的第一行代码
 
@@ -61,4 +61,4 @@ java:
 
 邮箱：<mailto:return65530@qq.com>
 
-开黑啦：Steve47876#0001
+Kook：Steve47876#0001

--- a/README_en.md
+++ b/README_en.md
@@ -2,11 +2,11 @@
 
 [简体中文](README.md) | **English**
 
-AN SDK to build bot on KHL for JVM platforms.
+An SDK to build bot on KOOK (formally KaiHeiLa) for JVM platforms.
 
 ## Quick Starting
 
-1. Download the latest jar at [Releases](https://github.com/zly2006/KhlKt/releases) or clone this repo and build.
+1. Download the latest jar at [Releases](https://github.com/zly2006/KookyBot/releases) or clone this repo and build.
 2. Create a java or kotlin project, and import it as library.
 3. Write your code like this.
 
@@ -47,4 +47,4 @@ This project is open-source under AGPL v3 license.
 
 email：<mailto:return65530@qq.com>
 
-KHL：Steve47876#0001
+Kook：Steve47876#0001

--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,9 @@ publishing {
                 }
             }
             pom {
-                name = 'KhlKt'
-                description = 'An SDK of KHL for JVM platforms.'
-                url = 'https://github.com/zly2006/KhlKt'
+                name = 'KookyBot'
+                description = 'An SDK of KOOK for JVM platforms.'
+                url = 'https://github.com/zly2006/KookyBot'
                 properties = [
                         myProp: "value",
                         "prop.with.dots": "anotherValue"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
-# KhlKt Docs
+# KookyBot Docs
+
 `Kotlin`
 
 ### 登录你的Bot

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'KhlKt'
+rootProject.name = 'KookyBot'

--- a/src/main/java/io/github/zly2006/kookybot/utils/DontUpdate.java
+++ b/src/main/java/io/github/zly2006/kookybot/utils/DontUpdate.java
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/JavaBaseClass.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/JavaBaseClass.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/Lanucher.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/Lanucher.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/client/Client.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/client/Client.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/client/Client.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/client/Client.kt
@@ -29,7 +29,7 @@ import io.github.zly2006.kookybot.data
 import io.github.zly2006.kookybot.events.EventManager
 import io.github.zly2006.kookybot.events.MessageEvent
 import io.github.zly2006.kookybot.events.SelfOnlineEvent
-import io.github.zly2006.kookybot.exception.KhlRemoteException
+import io.github.zly2006.kookybot.exception.KookRemoteException
 import io.github.zly2006.kookybot.message.SelfMessage
 import io.github.zly2006.kookybot.utils.Updatable
 import io.javalin.Javalin
@@ -239,7 +239,7 @@ class Client (var token : String) {
                 return json.get("data").asJsonObject
             }
             else -> {
-                throw KhlRemoteException(json.get("code").asInt, json.get("message").asString, request)
+                throw KookRemoteException(json.get("code").asInt, json.get("message").asString, request)
             }
         }
     }
@@ -290,7 +290,7 @@ class Client (var token : String) {
                                 self = Self(this@Client)
                             }
                             else -> {
-                                throw Exception("khl login failed: code is $code\n  @see <https://developer.kaiheila.cn/doc/websocket>")
+                                throw Exception("KOOK login failed: code is $code\n  @see <https://developer.kookapp.cn/doc/websocket>")
                             }
                         }
                     }
@@ -369,7 +369,7 @@ class Client (var token : String) {
             ) {
                 val challenge = json["challenge"].asString
                 ctx.contentType("application/json").result("{\"challenge\":\"$challenge\"}")
-                logger.info("[Khl] Received WEBHOOK_CHALLENGE request, challenge: $challenge, Responded")
+                logger.info("[KOOK] Received WEBHOOK_CHALLENGE request, challenge: $challenge, Responded")
                 status = State.Connected
                 self = Self(client = this@Client)
             }

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/Channel.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/Channel.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/Guild.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/Guild.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/GuildRole.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/GuildRole.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/GuildUser.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/GuildUser.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/MessageReceiver.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/MessageReceiver.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/NotifyType.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/NotifyType.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/PrivateChatUser.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/PrivateChatUser.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/Self.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/Self.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/User.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/User.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/contract/User.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/contract/User.kt
@@ -25,7 +25,7 @@ import io.github.zly2006.kookybot.message.Message
  * 此类型不会自动更新。
  * 每次使用都应该重新获取一遍，如
  *
- * @see com.github.zly2006.khlkt.contract.Self#getUser(String kotlin.userId)
+ * @see com.github.zly2006.kookybot.contract.Self#getUser(String kotlin.userId)
  */
 enum class UserState {
     NORMAL,

--- a/src/main/kotlin/io/github/zly2006/kookybot/data.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/data.kt
@@ -17,7 +17,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 package io.github.zly2006.kookybot
 
 object data {
-    val baseUrl = "https://www.kaiheila.cn"
-    val baseApiUrl = "https://www.kaiheila.cn/api/v3"
-
+    val baseUrl = "https://www.kookapp.cn"
+    val baseApiUrl = "https://www.kookapp.cn/api/v3"
 }

--- a/src/main/kotlin/io/github/zly2006/kookybot/data.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/data.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/ChannelMessageEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/ChannelMessageEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/Event.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/Event.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/EventManager.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/EventManager.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/MessageEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/MessageEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/RawEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/RawEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/SelfOnlineEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/SelfOnlineEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/SelfReLoginEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/SelfReLoginEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/events/SystemMessageEvent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/events/SystemMessageEvent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/exception/KhlRemoteException.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/exception/KhlRemoteException.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/exception/KookRemoteException.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/exception/KookRemoteException.kt
@@ -18,7 +18,7 @@ package io.github.zly2006.kookybot.exception
 
 import java.net.http.HttpRequest
 
-class KhlRemoteException(
+class KookRemoteException(
     val code: Int,
     override val message: String?,
     val request: HttpRequest? = null

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/At.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/At.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/CardMessage.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/CardMessage.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/MarkdownMessage.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/MarkdownMessage.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/Message.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/Message.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/MessageComponent.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/MessageComponent.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/message/SelfMessage.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/message/SelfMessage.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/utils/Permission.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/utils/Permission.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/utils/PermissionImpl.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/utils/PermissionImpl.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify

--- a/src/main/kotlin/io/github/zly2006/kookybot/utils/Updatable.kt
+++ b/src/main/kotlin/io/github/zly2006/kookybot/utils/Updatable.kt
@@ -1,4 +1,4 @@
-/* KhlKt - a SDK of <https://kaiheila.cn> for JVM platform
+/* KookyBot - a SDK of <https://www.kookapp.cn> for JVM platform
 Copyright (C) 2022, zly2006 & contributors
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
`开黑啦` 已重命名为 `KOOK`，虽然 commit  a87f3e1854d87cee71aca8dda75ddcd43fec5717 已经进行了一部分重构，但是重构内容仍然不完整。所以进行了本 Pull Request 包含的一些更改（均以测试且工作正常）。

## 本 Pull Request 包含以下变更：

* commit https://github.com/zly2006/KookyBot/commit/ad6eedde48d73feb5f446405834a1c94310dd7b9

  -  将 gitignore，版权信息，README，项目配置等不直接影响代码的内容中的 `KHL`/`KaiHeiLa`/`开黑啦` 更换为 `KOOK`

* commit https://github.com/zly2006/KookyBot/commit/bd0ed5c34c6c46ee7d65b5cedd35be8e098e8299

  - 将 `KhlRemoteException` 更改为 `KookRemoteException`
  - 将 `@see com.github.zly2006.khlkt.contract.Self#getUser(String kotlin.userId)` 注释的 `khlkt` 更改为 `kookybot`
  - 使用 `kookapp.cn` 的 URL 替换原先的开黑啦 API URL
  - 将一些 log/异常 信息中的 `KHL`/`KaiHeiLa`/`开黑啦` 更换为 `KOOK`